### PR TITLE
fix default image repository namespace

### DIFF
--- a/charts/syseleven-exporter-chart/values.yaml
+++ b/charts/syseleven-exporter-chart/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: staffbace/syseleven-exporter
+  repository: syseleven/syseleven-exporter
   pullPolicy: IfNotPresent
   tag:
 


### PR DESCRIPTION
```
docker pull staffbace/syseleven-exporter:1.2.0
Error response from daemon: manifest for staffbace/syseleven-exporter:1.2.0 not found: manifest unknown: manifest unknown
```
