### PR TITLE
Allow to skip validation for custom usecase

### DIFF
--- a/charts/syseleven-exporter-chart/templates/secret.yaml
+++ b/charts/syseleven-exporter-chart/templates/secret.yaml
@@ -1,9 +1,11 @@
 {{- if not .Values.existingSecret }}
+{{- if not .Values.openstack.skipValidation }}
 {{- if and (or .Values.openstack.username .Values.openstack.password) (or .Values.openstack.application_credential_id .Values.openstack.application_credential_secret) }}
 {{- fail "openstack.username/password and openstack.application_credential_id/application_credential_secret are mutually exclusive." }}
 {{- end }}
 {{- if not (or (and .Values.openstack.username .Values.openstack.password) (and .Values.openstack.application_credential_id .Values.openstack.application_credential_secret)) }}
 {{- fail "One of openstack.username/password or openstack.application_credential_id/application_credential_secret is required." }}
+{{- end }}
 {{- end }}
 apiVersion: v1
 kind: Secret

--- a/charts/syseleven-exporter-chart/tests/secret_test.yaml
+++ b/charts/syseleven-exporter-chart/tests/secret_test.yaml
@@ -1,0 +1,86 @@
+# tests/secret_test.yaml
+
+suite: Test Secret
+templates:
+  - templates/secret.yaml
+
+tests:
+  - it: should render secret with username and password
+    set:
+      openstack:
+        username: "test-user"
+        password: "test-password"
+        projectId: "test-project"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-syseleven-exporter
+      - equal:
+          path: stringData.OS_USERNAME
+          value: test-user
+      - equal:
+          path: stringData.OS_PASSWORD
+          value: test-password
+      - equal:
+          path: stringData.OS_PROJECT_ID
+          value: test-project
+
+  - it: should render secret with application_credential_id and secret
+    set:
+      openstack:
+        application_credential_id: "test-app-cred-id"
+        application_credential_secret: "test-app-cred-secret"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.OS_APPLICATION_CREDENTIAL_ID
+          value: test-app-cred-id
+      - equal:
+          path: stringData.OS_APPLICATION_CREDENTIAL_SECRET
+          value: test-app-cred-secret
+
+  - it: should not render secret when existingSecret is set
+    set:
+      existingSecret: "my-existing-secret"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render secret with empty credentials when skipValidation is true
+    set:
+      openstack:
+        skipValidation: true
+        projectId: "test-project"
+    asserts:
+      - isKind:
+          of: Secret
+      - hasDocuments:
+          count: 1
+
+  - it: should render secret with incomplete credentials when skipValidation is true
+    set:
+      openstack:
+        skipValidation: true
+        username: "test-user"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.OS_USERNAME
+          value: test-user
+
+  - it: should render secret with iam_org_id
+    set:
+      openstack:
+        username: "test-user"
+        password: "test-password"
+        iam_org_id: "test-org-id"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.IAM_ORG_ID
+          value: test-org-id

--- a/charts/syseleven-exporter-chart/values.yaml
+++ b/charts/syseleven-exporter-chart/values.yaml
@@ -151,3 +151,5 @@ openstack:
   apiversion: v1
   # Set if S3 is used in NCS - Can not be used with username and password!
   iam_org_id: ""
+  # Set to true to skip validation of OpenStack credentials
+  skipValidation: false


### PR DESCRIPTION
I need to insert OS_APPLICATION_CREDENTIAL_SECRET via my own crafted environment variable. It get's retrieved from OpenBao. This allows to set all non-secret values through the existing mechanism while allowing advanced usecases.