### PR TITLE
fix: correct Docker health check path from /_health to /health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="SysEleven GmbH"
 LABEL git.url="https://github.com/syseleven/syseleven-exporter"
 
 RUN apk add --no-cache --update curl ca-certificates
-HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD curl --fail http://localhost:8080/_health || exit 1
+HEALTHCHECK --interval=10s --timeout=3s --retries=3 CMD curl --fail http://localhost:8080/health || exit 1
 
 USER nobody
 


### PR DESCRIPTION
The healthcheck in the Dockerfile calls /_health but the application registers /health (syselevenexporter.go:123).

That means, every container has been reporting unhealthy since the route was defined.

only this character fix, no logic change.