### PR TITLE
pkg/api: return errors from MakeRequest to callers

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -44,6 +44,7 @@ func MakeRequest(url string, token string, header string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var apiError Error
@@ -71,7 +72,10 @@ func GetQuotaV3(projectID, token string) (map[string]QuotaV3, error) {
 		endpoint = os.Getenv("SYSELEVEN_QUOTA_API_ENDPOINT")
 	}
 	url := fmt.Sprintf("%s/v3/projects/%s/quota", endpoint, projectID)
-	resp, _ := MakeRequest(url, token, "X-Auth-Token")
+	resp, err := MakeRequest(url, token, "X-Auth-Token")
+	if err != nil {
+		return nil, fmt.Errorf("get quota v3: %w", err)
+	}
 
 	var quotas = make(map[string]QuotaV3)
 
@@ -84,7 +88,10 @@ func GetQuotaV3(projectID, token string) (map[string]QuotaV3, error) {
 
 func GetCurrentUsageV3(projectID, token string) (map[string]CurrentUsageV3, error) {
 	url := fmt.Sprintf("%s/v3/projects/%s/current_usage", endpoint, projectID)
-	resp, _ := MakeRequest(url, token, "X-Auth-Token")
+	resp, err := MakeRequest(url, token, "X-Auth-Token")
+	if err != nil {
+		return nil, fmt.Errorf("get current usage v3: %w", err)
+	}
 
 	var currentUsages = make(map[string]CurrentUsageV3)
 
@@ -105,11 +112,14 @@ func GetQuotaV1(projectID, token string) (map[string]QuotaV1, error) {
 	}
 
 	url := fmt.Sprintf("%s/v1/projects/%s/quota", endpoint, projectID)
-	resp, _ := MakeRequest(url, token, "X-Auth-Token")
+	resp, err := MakeRequest(url, token, "X-Auth-Token")
+	if err != nil {
+		return nil, fmt.Errorf("get quota v1: %w", err)
+	}
 
 	var quotas = make(map[string]QuotaV1)
 
-	err := json.Unmarshal(resp, &quotas)
+	err = json.Unmarshal(resp, &quotas)
 
 	if err != nil {
 		return nil, err
@@ -120,7 +130,10 @@ func GetQuotaV1(projectID, token string) (map[string]QuotaV1, error) {
 
 func GetCurrentUsageV1(projectID, token string) (map[string]CurrentUsageV1, error) {
 	url := fmt.Sprintf("%s/v1/projects/%s/current_usage", endpoint, projectID)
-	resp, _ := MakeRequest(url, token, "X-Auth-Token")
+	resp, err := MakeRequest(url, token, "X-Auth-Token")
+	if err != nil {
+		return nil, fmt.Errorf("get current usage v1: %w", err)
+	}
 
 	var currentUsages = make(map[string]CurrentUsageV1)
 
@@ -146,7 +159,10 @@ func GetS3InfoNCS(projectID string) ([]S3UsageNCS, error) {
 	s3Usage := []S3UsageNCS{}
 	for _, t := range s3Users {
 		url := fmt.Sprintf("%s/v3/orgs/%s/projects/%s/s3-users/%s/quota", endpointIam, orgID, projectID, t.Id)
-		resp, _ := MakeRequest(url, secret, "X-S11-CREDENTIAL")
+		resp, err := MakeRequest(url, secret, "X-S11-CREDENTIAL")
+		if err != nil {
+			return nil, fmt.Errorf("get s3 info ncs user %s: %w", t.Id, err)
+		}
 
 		var currentUsage S3InfoNCS
 
@@ -160,10 +176,13 @@ func GetS3InfoNCS(projectID string) ([]S3UsageNCS, error) {
 
 func GetS3Users(orgID, projectID, secret string) ([]S3UsersNCS, error) {
 	url := fmt.Sprintf("%s/v3/orgs/%s/projects/%s/s3-users", endpointIam, orgID, projectID)
-	resp, _ := MakeRequest(url, secret, "X-S11-CREDENTIAL")
+	resp, err := MakeRequest(url, secret, "X-S11-CREDENTIAL")
+	if err != nil {
+		return nil, fmt.Errorf("get s3 users: %w", err)
+	}
 
 	var s3users []S3UsersNCS
-	err := json.Unmarshal(resp, &s3users)
+	err = json.Unmarshal(resp, &s3users)
 
 	return s3users, err
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetQuotaV3_ErrorPropagation verifies that MakeRequest errors are
+// returned to the caller with full context, not silently discarded.
+//
+// Regression: PR #90 introduced resp, _ := MakeRequest(...) at every call
+// site, causing real API errors to be replaced by a generic json parse error
+// "unexpected end of JSON input". This made failures impossible to diagnose.
+func TestGetQuotaV3_ErrorPropagation(t *testing.T) {
+	t.Run("non-2xx response returns real API error message", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(Error{
+				Title:  "Internal Server Error",
+				Detail: "Keystone authentication failed — token expired",
+				Type:   "auth_error",
+			})
+		}))
+		defer srv.Close()
+		t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
+
+		_, err := GetQuotaV3("proj-abc", "bad-token")
+
+		if err == nil {
+			t.Fatal("got nil error — API failure was completely undetected")
+		}
+		if !strings.Contains(err.Error(), "get quota v3:") {
+			t.Fatalf("missing function context in error\n  want: contains %q\n  got:  %q", "get quota v3:", err.Error())
+		}
+		if !strings.Contains(err.Error(), "Keystone authentication failed") {
+			t.Fatalf("missing real API message in error\n  want: contains %q\n  got:  %q", "Keystone authentication failed", err.Error())
+		}
+		if strings.Contains(err.Error(), "unexpected end of JSON input") {
+			t.Fatalf("got misleading json parse error instead of real API error\n  got: %q", err.Error())
+		}
+	})
+
+	t.Run("unreachable API returns network error not json error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// close connection immediately — simulates dead API
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				w.WriteHeader(500)
+				return
+			}
+			conn, _, _ := hj.Hijack()
+			conn.Close()
+		}))
+		defer srv.Close()
+		t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
+
+		_, err := GetQuotaV3("proj-abc", "any-token")
+
+		if err == nil {
+			t.Fatal("got nil error — unreachable API was completely undetected")
+		}
+		if !strings.Contains(err.Error(), "get quota v3:") {
+			t.Fatalf("missing function context in error\n  want: contains %q\n  got:  %q", "get quota v3:", err.Error())
+		}
+		if strings.Contains(err.Error(), "unexpected end of JSON input") {
+			t.Fatalf("got misleading json parse error instead of network error\n  got: %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
## Description:

 All six `MakeRequest` call sites discarded the error with `resp, _`:
  
  - `GetQuotaV3`
  - `GetCurrentUsageV3`
  - `GetQuotaV1`
  - `GetCurrentUsageV1`
  - `GetS3InfoNCS`
  - `GetS3Users`

## Fix
Check the error at every call site, return it wrapped with `%w` and function context


## Note
Staffbase repo also has this error handling done, please check it here
https://github.com/Staffbase/syseleven-exporter/blob/master/pkg/api/api.go
