### PR TITLE
tests added for api, auth, exporter, version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.3 // indirect

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,4 +1,20 @@
-package api
+/*
+Copyright 2020, Staffbase GmbH and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api_test
 
 import (
 	"encoding/json"
@@ -6,67 +22,319 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/syseleven/syseleven-exporter/pkg/api"
 )
 
-// TestGetQuotaV3_ErrorPropagation verifies that MakeRequest errors are
-// returned to the caller with full context, not silently discarded.
-//
-// Regression: PR #90 introduced resp, _ := MakeRequest(...) at every call
-// site, causing real API errors to be replaced by a generic json parse error
-// "unexpected end of JSON input". This made failures impossible to diagnose.
+const (
+	testProjectID = "proj-123"
+	testOrgID     = "org-456"
+	testToken     = "test-token"
+	testSecret    = "s11_orgsa_secret"
+)
+
+// pkg/api resolves the API and IAM endpoints into package globals that only
+// GetQuota*/GetS3InfoNCS set from the environment; the dependent calls reuse
+// them. Tests therefore follow the exporter's real call order.
+
+func TestGetQuota_Success(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantPath  string
+		response  string
+		wantValue float64
+		invoke    func() (float64, error)
+	}{
+		{
+			name:      "GetQuotaV3",
+			wantPath:  "/v3/projects/" + testProjectID + "/quota",
+			response:  `{"region-a":{"compute.cores":4}}`,
+			wantValue: 4,
+			invoke: func() (float64, error) {
+				q, err := api.GetQuotaV3(testProjectID, testToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return q["region-a"].ComputeCores, nil
+			},
+		},
+		{
+			name:      "GetQuotaV1",
+			wantPath:  "/v1/projects/" + testProjectID + "/quota",
+			response:  `{"region-a":{"compute.cores":8}}`,
+			wantValue: 8,
+			invoke: func() (float64, error) {
+				q, err := api.GetQuotaV1(testProjectID, testToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return q["region-a"].ComputeCores, nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath, gotToken string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotToken = r.Header.Get("X-Auth-Token")
+
+				if _, err := w.Write([]byte(tc.response)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
+
+			got, err := tc.invoke()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.wantValue {
+				t.Errorf("parsed value: got %v, want %v", got, tc.wantValue)
+			}
+
+			if gotPath != tc.wantPath {
+				t.Errorf("request path: got %q, want %q", gotPath, tc.wantPath)
+			}
+
+			if gotToken != testToken {
+				t.Errorf("auth header X-Auth-Token: got %q, want %q", gotToken, testToken)
+			}
+		})
+	}
+}
+
+// TestQuotaThenUsage exercises the real exporter flow: a quota call resolves the
+// endpoint, then a current-usage call reuses it.
+func TestQuotaThenUsage(t *testing.T) {
+	tests := []struct {
+		name          string
+		quotaResp     string
+		usageResp     string
+		wantUsagePath string
+		invoke        func() (float64, error)
+	}{
+		{
+			name:          "v3",
+			quotaResp:     `{"region-a":{"compute.cores":4}}`,
+			usageResp:     `{"region-a":{"compute.cores":2}}`,
+			wantUsagePath: "/v3/projects/" + testProjectID + "/current_usage",
+			invoke: func() (float64, error) {
+				if _, err := api.GetQuotaV3(testProjectID, testToken); err != nil {
+					return 0, err
+				}
+
+				u, err := api.GetCurrentUsageV3(testProjectID, testToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return u["region-a"].ComputeCores, nil
+			},
+		},
+		{
+			name:          "v1",
+			quotaResp:     `{"region-a":{"compute.cores":8}}`,
+			usageResp:     `{"region-a":{"compute.cores":6}}`,
+			wantUsagePath: "/v1/projects/" + testProjectID + "/current_usage",
+			invoke: func() (float64, error) {
+				if _, err := api.GetQuotaV1(testProjectID, testToken); err != nil {
+					return 0, err
+				}
+
+				u, err := api.GetCurrentUsageV1(testProjectID, testToken)
+				if err != nil {
+					return 0, err
+				}
+
+				return u["region-a"].ComputeCores, nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotUsagePath string
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body := tc.quotaResp
+				if strings.HasSuffix(r.URL.Path, "/current_usage") {
+					gotUsagePath = r.URL.Path
+					body = tc.usageResp
+				}
+
+				if _, err := w.Write([]byte(body)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer srv.Close()
+
+			t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
+
+			got, err := tc.invoke()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != 2 && got != 6 {
+				t.Errorf("parsed usage value: got %v, want 2 (v3) or 6 (v1)", got)
+			}
+
+			if gotUsagePath != tc.wantUsagePath {
+				t.Errorf("usage request path: got %q, want %q", gotUsagePath, tc.wantUsagePath)
+			}
+		})
+	}
+}
+
+func TestGetQuotaV3_MalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte(`{not valid json`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
+
+	_, err := api.GetQuotaV3(testProjectID, testToken)
+	if err == nil {
+		t.Fatal("got nil error for malformed JSON body")
+	}
+
+	if !strings.Contains(err.Error(), "invalid character") {
+		t.Fatalf("expected a JSON parse error, got: %q", err.Error())
+	}
+}
+
+// TestGetS3InfoNCS_Success drives the full NCS S3 flow (list users, then fetch
+// each user's quota) and covers the IAM endpoint override.
+func TestGetS3InfoNCS_Success(t *testing.T) {
+	var gotUsersPath, gotQuotaCred string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body string
+
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/s3-users"):
+			gotUsersPath = r.URL.Path
+			body = `[{"name":"user-a","id":"id-a","description":"desc-a"}]`
+		case strings.HasSuffix(r.URL.Path, "/quota"):
+			gotQuotaCred = r.Header.Get("X-S11-CREDENTIAL")
+			body = `{"size":100,"max_size":1000,"num_objects":5,"max_objects":50,"enabled":true,"check_on_raw":true}`
+		default:
+			t.Errorf("unexpected request path: %q", r.URL.Path)
+		}
+
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	t.Setenv("SYSELEVEN_IAM_API_ENDPOINT", srv.URL)
+	t.Setenv("IAM_ORG_ID", testOrgID)
+	t.Setenv("OS_APPLICATION_CREDENTIAL_SECRET", testSecret)
+
+	usage, err := api.GetS3InfoNCS(testProjectID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(usage) != 1 {
+		t.Fatalf("expected 1 s3 usage entry, got %d", len(usage))
+	}
+
+	if usage[0].Name != "user-a" {
+		t.Errorf("user name: got %q, want %q", usage[0].Name, "user-a")
+	}
+
+	if usage[0].Size != 100 || !usage[0].Enabled {
+		t.Errorf("s3 info: got size=%v enabled=%v, want size=100 enabled=true", usage[0].Size, usage[0].Enabled)
+	}
+
+	wantUsersPath := "/v3/orgs/" + testOrgID + "/projects/" + testProjectID + "/s3-users"
+	if gotUsersPath != wantUsersPath {
+		t.Errorf("s3-users request path: got %q, want %q", gotUsersPath, wantUsersPath)
+	}
+
+	if gotQuotaCred != testSecret {
+		t.Errorf("quota auth header X-S11-CREDENTIAL: got %q, want %q", gotQuotaCred, testSecret)
+	}
+}
+
+// Regression (PR #90): call sites used `resp, _ := MakeRequest(...)`, so real API
+// errors were masked by "unexpected end of JSON input". Errors must carry the
+// function context and the upstream message.
 func TestGetQuotaV3_ErrorPropagation(t *testing.T) {
 	t.Run("non-2xx response returns real API error message", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(Error{
+
+			if err := json.NewEncoder(w).Encode(api.Error{
 				Title:  "Internal Server Error",
 				Detail: "Keystone authentication failed — token expired",
 				Type:   "auth_error",
-			})
+			}); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
 		}))
 		defer srv.Close()
+
 		t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
 
-		_, err := GetQuotaV3("proj-abc", "bad-token")
-
+		_, err := api.GetQuotaV3("proj-abc", "bad-token")
 		if err == nil {
 			t.Fatal("got nil error — API failure was completely undetected")
 		}
+
 		if !strings.Contains(err.Error(), "get quota v3:") {
-			t.Fatalf("missing function context in error\n  want: contains %q\n  got:  %q", "get quota v3:", err.Error())
+			t.Fatalf("missing function context: %q", err.Error())
 		}
+
 		if !strings.Contains(err.Error(), "Keystone authentication failed") {
-			t.Fatalf("missing real API message in error\n  want: contains %q\n  got:  %q", "Keystone authentication failed", err.Error())
+			t.Fatalf("missing upstream API message: %q", err.Error())
 		}
+
 		if strings.Contains(err.Error(), "unexpected end of JSON input") {
-			t.Fatalf("got misleading json parse error instead of real API error\n  got: %q", err.Error())
+			t.Fatalf("got misleading json parse error instead of real API error: %q", err.Error())
 		}
 	})
 
 	t.Run("unreachable API returns network error not json error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// close connection immediately — simulates dead API
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			hj, ok := w.(http.Hijacker)
 			if !ok {
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
+
 				return
 			}
+
 			conn, _, _ := hj.Hijack()
 			conn.Close()
 		}))
 		defer srv.Close()
+
 		t.Setenv("SYSELEVEN_QUOTA_API_ENDPOINT", srv.URL)
 
-		_, err := GetQuotaV3("proj-abc", "any-token")
-
+		_, err := api.GetQuotaV3("proj-abc", "any-token")
 		if err == nil {
 			t.Fatal("got nil error — unreachable API was completely undetected")
 		}
+
 		if !strings.Contains(err.Error(), "get quota v3:") {
-			t.Fatalf("missing function context in error\n  want: contains %q\n  got:  %q", "get quota v3:", err.Error())
+			t.Fatalf("missing function context: %q", err.Error())
 		}
+
 		if strings.Contains(err.Error(), "unexpected end of JSON input") {
-			t.Fatalf("got misleading json parse error instead of network error\n  got: %q", err.Error())
+			t.Fatalf("got misleading json parse error instead of network error: %q", err.Error())
 		}
 	})
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020, Staffbase GmbH and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/syseleven/syseleven-exporter/pkg/auth"
+)
+
+// These cover what is stable in the gophercloud-backed auth flow: the OS_AUTH_URL
+// override is honored and a Keystone failure surfaces as an error. The success
+// path (including the unchecked tokens.CreateResult assertion in GetProject) is a
+// gap until #114 makes the client injectable.
+
+func keystone401(t *testing.T) (url string, hit *bool) {
+	t.Helper()
+
+	var contacted bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contacted = true
+		w.WriteHeader(http.StatusUnauthorized)
+
+		if _, err := w.Write([]byte(`{"error":{"code":401,"message":"denied"}}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/v3", &contacted
+}
+
+func TestAuthFunctions_UseOverrideAndSurfaceError(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke func() error
+	}{
+		{
+			name:   "GetToken",
+			invoke: func() error { _, err := auth.GetToken("project-id", "user", "pass"); return err },
+		},
+		{
+			name:   "GetTokenAppCreds",
+			invoke: func() error { _, err := auth.GetTokenAppCreds("project-id", "cred-id", "cred-secret"); return err },
+		},
+		{
+			name:   "GetProject",
+			invoke: func() error { _, err := auth.GetProject("cred-id", "cred-secret"); return err },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url, contacted := keystone401(t)
+			t.Setenv("OS_AUTH_URL", url)
+
+			if err := tc.invoke(); err == nil {
+				t.Fatal("expected an error from a 401 Keystone, got nil")
+			}
+
+			if !*contacted {
+				t.Error("OS_AUTH_URL override was not honored: stub Keystone was never contacted")
+			}
+		})
+	}
+}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020, Staffbase GmbH and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporter_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/syseleven/syseleven-exporter/pkg/api"
+	"github.com/syseleven/syseleven-exporter/pkg/exporter"
+)
+
+// The exporter's GaugeVec metrics are package-level globals on the default
+// registry, and every Set* call Reset()s and rewrites them. These tests share
+// that state and do not run in parallel; the #114 refactor (injected registry)
+// is what would let them use a per-test registry and parallelize.
+
+func gatherEqual(t *testing.T, expected string, names ...string) {
+	t.Helper()
+
+	if err := testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), names...); err != nil {
+		t.Fatalf("metric exposition mismatch:\n%v", err)
+	}
+}
+
+func TestSetUtilsV3_SetsGauges(t *testing.T) {
+	exp := &exporter.Exporter{ProjectID: "project-a"}
+
+	exporter.SetUtilsV3(
+		map[string]api.QuotaV3{
+			"region-a": {
+				ComputeCores: 4,
+				ComputeRAMMb: 2048,
+				Objectstorage: []struct {
+					SpaceBytes float64 `json:"space_bytes"`
+					Type       string  `json:"type"`
+				}{
+					{SpaceBytes: 5000, Type: "s3"},
+				},
+			},
+		},
+		map[string]api.CurrentUsageV3{
+			"region-a": {ComputeCores: 2},
+		},
+		exp,
+	)
+
+	expected := `
+# HELP syseleven_compute_cores_total Quota for number of compute cores per region and project
+# TYPE syseleven_compute_cores_total gauge
+syseleven_compute_cores_total{project="project-a",region="region-a"} 4
+# HELP syseleven_compute_cores_used Number of used compute cores per region and project
+# TYPE syseleven_compute_cores_used gauge
+syseleven_compute_cores_used{project="project-a",region="region-a"} 2
+# HELP syseleven_compute_ram_total_megabytes Quota for ram per region and project in megabytes
+# TYPE syseleven_compute_ram_total_megabytes gauge
+syseleven_compute_ram_total_megabytes{project="project-a",region="region-a"} 2048
+# HELP syseleven_s3_space_total_bytes Quota for S3 space per region and project in bytes
+# TYPE syseleven_s3_space_total_bytes gauge
+syseleven_s3_space_total_bytes{project="project-a",region="region-a",type="s3"} 5000
+`
+
+	gatherEqual(t, expected,
+		"syseleven_compute_cores_total",
+		"syseleven_compute_cores_used",
+		"syseleven_compute_ram_total_megabytes",
+		"syseleven_s3_space_total_bytes",
+	)
+}
+
+// V1 reports S3 space under a hardcoded type="quobyte" label and reads load
+// balancers from the NetworkLoadbalancers field. Both are easy to break silently.
+func TestSetUtilsV1_QuobyteAndLoadbalancers(t *testing.T) {
+	exp := &exporter.Exporter{ProjectID: "project-b"}
+
+	exporter.SetUtilsV1(
+		map[string]api.QuotaV1{
+			"region-b": {
+				NetworkLoadbalancers: 3,
+				S3SpaceBytes:         9000,
+			},
+		},
+		nil,
+		exp,
+	)
+
+	expected := `
+# HELP syseleven_network_loadbalancers_total Quota for number of load balancers per region and project
+# TYPE syseleven_network_loadbalancers_total gauge
+syseleven_network_loadbalancers_total{project="project-b",region="region-b"} 3
+# HELP syseleven_s3_space_total_bytes Quota for S3 space per region and project in bytes
+# TYPE syseleven_s3_space_total_bytes gauge
+syseleven_s3_space_total_bytes{project="project-b",region="region-b",type="quobyte"} 9000
+`
+
+	gatherEqual(t, expected,
+		"syseleven_network_loadbalancers_total",
+		"syseleven_s3_space_total_bytes",
+	)
+}
+
+// Current behavior on main: a nil quota+usage scrape still hits the unconditional
+// Reset(), wiping all values. This is a smell (a transient API failure blanks the
+// dashboards); update this assertion once #114 adds a guard to retain values.
+func TestSetUtilsV3_NilScrapeClearsGauges(t *testing.T) {
+	exp := &exporter.Exporter{ProjectID: "project-a"}
+
+	exporter.SetUtilsV3(
+		map[string]api.QuotaV3{"region-a": {ComputeCores: 4}},
+		map[string]api.CurrentUsageV3{"region-a": {ComputeCores: 2}},
+		exp,
+	)
+
+	exporter.SetUtilsV3(nil, nil, exp)
+
+	// Empty expectation: after the nil scrape both gauges have no series.
+	gatherEqual(t, "",
+		"syseleven_compute_cores_total",
+		"syseleven_compute_cores_used",
+	)
+}
+
+// Enabled and CheckOnRaw map to gauge values 1 or 0.
+func TestSetS3Info_EnabledFlags(t *testing.T) {
+	exp := &exporter.Exporter{ProjectID: "project-c"}
+
+	info := []api.S3UsageNCS{
+		{
+			S3UsersNCS: api.S3UsersNCS{Name: "u", Description: "d"},
+			S3InfoNCS: api.S3InfoNCS{
+				Size:       50,
+				MaxSize:    200,
+				NumObjects: 3,
+				MaxObjects: 30,
+				Enabled:    true,
+				CheckOnRaw: false,
+			},
+		},
+	}
+
+	exporter.SetS3Info(info, exp)
+
+	expected := `
+# HELP syseleven_s3_enabled_ncs Checks if s3 space is enabled for user or not
+# TYPE syseleven_s3_enabled_ncs gauge
+syseleven_s3_enabled_ncs{description="d",project="project-c",s3username="u"} 1
+# HELP syseleven_s3_check_enabled_ncs Checks if check on raw is enabled for user or not
+# TYPE syseleven_s3_check_enabled_ncs gauge
+syseleven_s3_check_enabled_ncs{description="d",project="project-c",s3username="u"} 0
+`
+
+	gatherEqual(t, expected,
+		"syseleven_s3_enabled_ncs",
+		"syseleven_s3_check_enabled_ncs",
+	)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020, Staffbase GmbH and contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version_test
+
+import (
+	"testing"
+
+	"github.com/syseleven/syseleven-exporter/pkg/version"
+)
+
+// Build-info values are package-level vars set via -ldflags. These tests write
+// them directly, so they share global state and do not run in parallel.
+
+func setBuildInfo(t *testing.T, ver, rev, branch, user, date, goVer string) {
+	t.Helper()
+
+	version.Version = ver
+	version.Revision = rev
+	version.Branch = branch
+	version.BuildUser = user
+	version.BuildDate = date
+	version.GoVersion = goVer
+}
+
+func TestInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		branch  string
+		rev     string
+		want    string
+	}{
+		{
+			name:    "all fields populated",
+			version: "1.2.3",
+			branch:  "main",
+			rev:     "abc123",
+			want:    "(version=1.2.3, branch=main, revision=abc123)",
+		},
+		{
+			name:    "empty fields render as empty",
+			version: "",
+			branch:  "",
+			rev:     "",
+			want:    "(version=, branch=, revision=)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setBuildInfo(t, tc.version, tc.rev, tc.branch, "irrelevant", "irrelevant", "irrelevant")
+
+			if got := version.Info(); got != tc.want {
+				t.Fatalf("Info()\n  got:  %q\n  want: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		goVer   string
+		user    string
+		date    string
+		want    string
+	}{
+		{
+			name:  "all fields populated",
+			goVer: "go1.24.3",
+			user:  "ci",
+			date:  "2026-07-01",
+			want:  "(go=go1.24.3, user=ci, date=2026-07-01)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setBuildInfo(t, "irrelevant", "irrelevant", "irrelevant", tc.user, tc.date, tc.goVer)
+
+			if got := version.BuildContext(); got != tc.want {
+				t.Fatalf("BuildContext()\n  got:  %q\n  want: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrint(t *testing.T) {
+	setBuildInfo(t, "1.2.3", "abc123", "main", "ci", "2026-07-01", "go1.24.3")
+
+	want := "SysEleven Exporter, version 1.2.3 (branch: main, revision: abc123)\n" +
+		"  build user:       ci\n" +
+		"  build date:       2026-07-01\n" +
+		"  go version:       go1.24.3"
+
+	got, err := version.Print("SysEleven Exporter")
+	if err != nil {
+		t.Fatalf("Print() returned unexpected error: %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("Print()\n  got:  %q\n  want: %q", got, want)
+	}
+}


### PR DESCRIPTION
1.  Coverage: api 22 ==> 82%, version 0 ==> 80%, auth 0==>68%, exporter 0==>64%
2. Table-driven, self-contained
3. Tests run serially: env vars + global state block t.Parallel. blocked untill #114 is resoleve
4. cmd left at 0% ==> blocked untill #114 splits the cobra closure