### PR TITLE
fix: adapt s3 info to new v3 IAM output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ docker pull syseleven/syseleven-exporter:<TAG>
 | syseleven_s3_space_max_bytes_ncs | Quota for S3 space in ncs regions in bytes |
 | syseleven_s3_space_used_bytes_ncs | Used S3 space in ncs regions in bytes |
 | syseleven_s3_num_objects_ncs | Number of objects stored in S3 |
-| syseleven_s3_max_objects_ncs | Maximal number of objects stored in S3 |
+| syseleven_s3_max_objects_ncs | Maximal number of objects stored in S3 per user quota |
+| syseleven_s3_max_objects_bucket_ncs | Maximal number of objects stored in S3 per bucket quota |
 | syseleven_s3_enabled_ncs | Checks if s3 space is enabled for user or not |
 | syseleven_s3_check_enabled_ncs | Checks if check on raw is enabled for user or not |
 | syseleven_volume_space_total_gigabytes | Quota for volume space per `region` and `project` in gigabytes |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -147,14 +147,15 @@ type S3UsersNCS struct {
 	Description string `json:"description"`
 }
 type S3InfoNCS struct {
-	SizeKB     float64 `json:"size_kb"`
-	Size       float64 `json:"size"`
-	MaxSizeKB  float64 `json:"max_size_kb"`
-	MaxSize    float64 `json:"max_size"`
-	NumObjects float64 `json:"num_objects"`
-	MaxObjects float64 `json:"max_objects"`
-	Enabled    bool    `json:"enabled"`
-	CheckOnRaw bool    `json:"check_on_raw"`
+	SizeKB           float64 `json:"size_kb"`
+	Size             float64 `json:"size"`
+	MaxSizeKB        float64 `json:"max_size_kb"`
+	MaxSize          float64 `json:"max_size"`
+	NumObjects       float64 `json:"num_objects"`
+	MaxObjectsUser   float64 `json:"max_objects_user_quota"`
+	MaxObjectsBucket float64 `json:"max_objects_bucket_quota"`
+	Enabled          bool    `json:"enabled"`
+	CheckOnRaw       bool    `json:"check_on_raw"`
 }
 
 type S3UsageNCS struct {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -161,11 +161,13 @@ func SetS3Info(s3infoncs []api.S3UsageNCS, exporter *Exporter) {
 	s3CheckEnabledNcs.Reset()
 	s3NumObjectsNcs.Reset()
 	s3MaxObjectsNcs.Reset()
+	s3MaxObjectsBucketNcs.Reset()
 	for _, v := range s3infoncs {
 		s3SpaceMaxBytesNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.MaxSize)
 		s3SpaceUsedBytesNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.Size)
 		s3NumObjectsNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.NumObjects)
-		s3MaxObjectsNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.MaxObjects)
+		s3MaxObjectsNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.MaxObjectsUser)
+		s3MaxObjectsBucketNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(v.MaxObjectsBucket)
 		if v.Enabled {
 			s3EnabledNcs.With(prometheus.Labels{"project": exporter.ProjectID, "s3username": v.Name, "description": v.Description}).Set(1)
 		} else {

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -147,7 +147,13 @@ var (
 	s3MaxObjectsNcs = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "s3_max_objects_ncs",
-		Help:      "Maximal number of objects stored in S3",
+		Help:      "Maximal number of objects stored in S3 per user quota",
+	}, []string{"project", "s3username", "description"})
+
+	s3MaxObjectsBucketNcs = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "s3_max_objects_bucket_ncs",
+		Help:      "Maximal number of objects stored in S3 per bucket quota",
 	}, []string{"project", "s3username", "description"})
 
 	volumeSpaceTotalGigabytes = promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Hey in svc-1396 we got the request to change the output of the s3 user endpoint in the IAM api. This chang enow broke something on a customers end since we renamed a field from `max_objects` to `max_objects_user_quota`. This caused the original `max_objects` field to be reported as 0. See zendesk ticket 189081
We also added a new field called `max_objects_bucket_quota` which I added as well. 
